### PR TITLE
Fix format in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -12,7 +12,10 @@ msmtp:
       auto_from: on
       maildomain: example.com
   aliases:
-    root: root@example.com
-    cron: root@example.com
-    default: root@example.com
+    root:
+      - root@example.com
+    cron:
+      - root@example.com
+    default:
+      - root@example.com
   default_account: example


### PR DESCRIPTION
When not using an array, the e-mail address will be seen as the array and joined as 'r,o,o,t,@,e,x,a,m,p,l,e,.,c.o.m'